### PR TITLE
IE8/9 Compatibility Fix;

### DIFF
--- a/paylane/paylane.js
+++ b/paylane/paylane.js
@@ -268,22 +268,10 @@
 					options.success.call(request, data);
 				}
 
-				request.onreadystatechange = function()
+				request.onerror = function()
 				{
-					if (request.DONE === request.readyState)
-					{
-						switch (request.status)
-						{
-							case 200:
-								var data = JSON.parse(request.responseText);
-								options.success.call(request, data);
-								break;
-
-							default:
-								options.error.call(request);
-						}
-					}
-				};
+					options.error.call(request);
+				}
 
 				request.send(data);
 			},


### PR DESCRIPTION
In IE8 check with instanceof HTMLElement/HTMLFormElement do not work (of course it may be better to implement them in different way instead of removing them).

Also in IE8/9 XDomainRequest should be used instead of XMLHttpRequest for cross domain requests.
